### PR TITLE
Changes to support pfSense v2.0. Don't ask why. ;^P

### DIFF
--- a/library/pfsense_setup.py
+++ b/library/pfsense_setup.py
@@ -188,6 +188,8 @@ SETUP_ARGUMENT_SPEC = dict(
     roworderdragging=dict(required=False, type='bool'),
     logincss=dict(required=False, type='str'),
     loginshowhost=dict(required=False, type='bool'),
+    disablechecksumoffloading=dict(required=False, type='bool'),
+    enablesshd=dict(required=False, type='bool'),
 )
 
 
@@ -326,6 +328,9 @@ class PFSenseSetupModule(PFSenseModuleBase):
 
         _set_param_bool(obj, 'dnsallowoverride')
         _set_param_bool(obj, 'dnslocalhost')
+
+        _set_param_bool(obj, 'disablechecksumoffloading')
+        _set_param_bool(obj, 'enablesshd')
 
         self._dns_params_to_obj(params, obj)
 
@@ -544,6 +549,9 @@ $retval |= system_ntp_configure();'''
         values += self.format_updated_cli_field(webgui, bwebgui, 'roworderdragging', fvalue=self.fvalue_bool, add_comma=(values), log_none=False)
         values += self.format_updated_cli_field(webgui, bwebgui, 'logincss', add_comma=(values), log_none=False)
         values += self.format_updated_cli_field(webgui, bwebgui, 'loginshowhost', fvalue=self.fvalue_bool, add_comma=(values), log_none=False)
+
+        values += self.format_updated_cli_field(webgui, bwebgui, 'disablechecksumoffloading', fvalue=self.fvalue_bool, add_comma=(values), log_none=False)
+        values += self.format_updated_cli_field(webgui, bwebgui, 'enablesshd', fvalue=self.fvalue_bool, add_comma=(values), log_none=False)
 
         return values
 

--- a/module_utils/network/pfsense/interface.py
+++ b/module_utils/network/pfsense/interface.py
@@ -380,6 +380,7 @@ class PFSenseInterfaceModule(PFSenseModuleBase):
     def _get_interface_list(self):
         return self.pfsense.php(
             "require_once('/etc/inc/interfaces.inc');"
+            "require_once('/etc/inc/util.inc');"
             "$portlist = get_interface_list();"
             ""
             "/* add wireless clone interfaces */"
@@ -435,7 +436,7 @@ class PFSenseInterfaceModule(PFSenseModuleBase):
             "$ipsec_descrs = interface_ipsec_vti_list_all();"
             "foreach ($ipsec_descrs as $ifname => $ifdescr) $portlist[$ifname] = array('descr' => $ifdescr);"
             ""
-            "echo json_encode($portlist, JSON_PRETTY_PRINT);")
+            "echo json_encode($portlist);")
 
     def _get_media_mode(self, interface):
         """ Find all possible media options for the interface """
@@ -458,6 +459,9 @@ class PFSenseInterfaceModule(PFSenseModuleBase):
         """ build and return php commands to setup interfaces """
         cmd = 'require_once("filter.inc");\n'
         cmd += 'require_once("interfaces.inc");\n'
+        cmd += 'require_once("util.inc");\n'
+        cmd += 'require_once("vpn.inc");\n'
+        cmd += 'require_once("captiveportal.inc");\n'
         cmd += 'require_once("services.inc");\n'
         cmd += 'require_once("gwlb.inc");\n'
         cmd += 'require_once("rrd.inc");\n'

--- a/module_utils/network/pfsense/pfsense.py
+++ b/module_utils/network/pfsense/pfsense.py
@@ -480,27 +480,28 @@ class PFSenseModule(object):
 
     def find_gateway_elt(self, name, interface=None, protocol=None, dhcp=False, vti=False):
         """ return gateway elt if found """
-        for gw_elt in self.gateways:
-            if gw_elt.tag != 'gateway_item':
-                continue
+        if self.gateways is not None:
+            for gw_elt in self.gateways:
+                if gw_elt.tag != 'gateway_item':
+                    continue
 
-            if protocol is not None and gw_elt.find('ipprotocol').text != protocol:
-                continue
+                if protocol is not None and gw_elt.find('ipprotocol').text != protocol:
+                    continue
 
-            if interface is not None and gw_elt.find('interface').text != interface:
-                continue
+                if interface is not None and gw_elt.find('interface').text != interface:
+                    continue
 
-            if gw_elt.find('name').text == name:
-                return gw_elt
+                if gw_elt.find('name').text == name:
+                    return gw_elt
 
-        for interface_elt in self.interfaces:
-            descr_elt = interface_elt.find('descr')
-            if descr_elt is None or descr_elt.text is None:
-                continue
+            for interface_elt in self.interfaces:
+                descr_elt = interface_elt.find('descr')
+                if descr_elt is None or descr_elt.text is None:
+                    continue
 
-            if_elt = interface_elt.find('if')
-            if if_elt is None or if_elt.text is None:
-                continue
+                if_elt = interface_elt.find('if')
+                if if_elt is None or if_elt.text is None:
+                    continue
 
             descr_text = descr_elt.text.strip().upper()
 
@@ -603,7 +604,7 @@ class PFSenseModule(object):
         if sys.version_info >= (3, 4):
             self.tree.write(tmp_name, xml_declaration=True, method='xml', short_empty_elements=False)
         else:
-            self.tree.write(tmp_name, xml_declaration=True, method='xml')
+            self.tree.write(tmp_name)
         shutil.move(tmp_name, self.config)
         os.chmod(self.config, 0o644)
         try:


### PR DESCRIPTION
* Added two features to pfsense_setup: disablechecksumoffloading and enablesshd.  This change has nothing to do with v2.0, I just needed these command options.

* The py26-json function, json_encode, a la FreeBSD 8.1, only takes one argument.

* Added checking for None type before iterating in pfsense.py

* Some pfSense php functions reside in different include files back in pfSense v2.0.

* And the version of xml.etree.ElementTree 'write' only takes 1 argument.